### PR TITLE
new `startIndex` and `resize` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ class App extends Component {
         data$={this.state.data}
         options$={of({ height: 60 })}
         style={{ height: 400, border: '1px solid black' }}>
-        {item => <p style={{ height: 59, margin: 0, borderBottom: '1px solid green' }}>No. {item}</p>}
+        {(item, index) => <p style={{ height: 59, margin: 0, borderBottom: '1px solid green' }}>No. {index} - {item}</p>}
       </VirtualList>
     );
   }

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ npm install --save vist
 ## Usage
 
 ```javascript
-import React from 'react'
-import { VirtualList } from 'vist'
+import React from 'react';
+import { VirtualList } from 'vist';
 
 class App extends Component {
   constructor(props) {
@@ -36,13 +36,8 @@ class App extends Component {
       <VirtualList
         data$={this.state.data}
         options$={of({ height: 60 })}
-        style={{ height: 400, border: '1px solid black' }}
-      >
-        {item => (
-          <p style={{ height: 59, margin: 0, borderBottom: '1px solid green' }}>
-            No. {item}
-          </p>
-        )}
+        style={{ height: 400, border: '1px solid black' }}>
+        {item => <p style={{ height: 59, margin: 0, borderBottom: '1px solid green' }}>No. {item}</p>}
       </VirtualList>
     );
   }
@@ -51,15 +46,21 @@ class App extends Component {
 
 ## Props
 
-* `data$`: `Observable<any>` data source of the list.
-* `options$`: `Observable<IVirtualListOptions>` options of the virtual list.
-* `style`: style of VirtualList container.
+| Property   | Type                              | Description                     |
+| ---------- | --------------------------------- | ------------------------------- |
+| `data$`    | `Observable<any>`                 | Data source of the list.        |
+| `options$` | `Observable<IVirtualListOptions>` | Options of the virtual list.    |
+| `style`    | `any`                             | Style of VirtualList container. |
 
-IVirtualListOptions
+### `IVirtualListOptions`
 
-* `height`: `number` item height, it's **necessary**, vist use this property to calculate how many rows should be rendered actually.
-* `spare`: `number` default 3 spare rows out of the view.
-* `sticky`: `boolean` default true, which means whether scrollTop need to stick to the container's top when the data is changed.
+| Property     | Type      | Default      | Description                                                                                                     |
+| ------------ | --------- | ------------ | --------------------------------------------------------------------------------------------------------------- |
+| `height`     | `number`  | **NOT NULL** | Item height, it's **necessary**, vist use this property to calculate how many rows should be rendered actually. |
+| `spare`      | `number`  | 3            | Spare rows out of the view.                                                                                     |
+| `sticky`     | `boolean` | true         | Whether the scrollTop need to stick to the container's top when the data is changed or not.                     |
+| `startIndex` | `number`  | 0            | To indicate this start index of the list, and the list will scroll to this start index position when mounted.   |
+| `resize`     | `boolean` | true         | To mark if the real dom number should be recomputed when the window resize.                                     |
 
 ## License
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -54,7 +54,7 @@ class App extends Component {
         <div className="virtual-box">
           <VirtualList
             data$={this.state.data}
-            options$={of({ height: 180 })}
+            options$={of({ height: 180, startIndex: 3000 })}
             style={{ height: '70vh' }}
           >
             {item => (

--- a/src/VirtualList.tsx
+++ b/src/VirtualList.tsx
@@ -109,7 +109,7 @@ export class VirtualList<T> extends React.Component<Readonly<IVirtualListProps<T
         filter(options => Boolean(options.length)),
         map(options => options[options.length - 1]),
         filter(option => option.startIndex !== undefined),
-        map(option => (option.startIndex! - 1) * option.height)
+        map(option => option.startIndex! * option.height)
         // setTimeout to make sure the list is already rendered
       ).subscribe(scrollTop => setTimeout(() => virtualListElm.scrollTo(0, scrollTop)))
     );
@@ -230,7 +230,7 @@ export class VirtualList<T> extends React.Component<Readonly<IVirtualListProps<T
               className={style.VirtualListPlaceholder}
               style={{ transform: `translateY(${data.$pos}px)` }}
             >
-              {data.origin !== undefined ? (this.props.children as any)(data.origin) : null}
+              {data.origin !== undefined ? (this.props.children as any)(data.origin, data.$index) : null}
             </div>)}
         </div>
       </div>


### PR DESCRIPTION
# New Api Support

## `startIndex`

To indicate this start index of the list, and the list will scroll to this start index position when mounted.

## `resize`

To mark if the real dom number should be recomputed when the window resize.

### Why use `resize` Api?

Think about this scenario: you wrote a dropdown list, when the you close the dropdown list and then resize the window. We cannot get the right size of the container, so it will have a strange behavior (the wrong number of the real dom). So in this case, you may need to switch off the resize feature.