### PR TITLE
Refactor/virtual list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ class App extends Component {
         data$={this.state.data}
         options$={of({ height: 60 })}
         style={{ height: 400, border: '1px solid black' }}>
-        {(item, index) => <p style={{ height: 59, margin: 0, borderBottom: '1px solid green' }}>No. {index} - {item}</p>}
+        {(item, index) => (
+          <p style={{ height: 59, margin: 0, borderBottom: '1px solid green' }}>
+            No. {index} - {item}
+          </p>
+        )}
       </VirtualList>
     );
   }
@@ -46,11 +50,14 @@ class App extends Component {
 
 ## Props
 
-| Property   | Type                              | Description                     |
-| ---------- | --------------------------------- | ------------------------------- |
-| `data$`    | `Observable<any>`                 | Data source of the list.        |
-| `options$` | `Observable<IVirtualListOptions>` | Options of the virtual list.    |
-| `style`    | `any`                             | Style of VirtualList container. |
+| Property    | Type                              | Description                         |
+| ----------- | --------------------------------- | ----------------------------------- |
+| `data$`     | `Observable<any>`                 | Data source of the list.            |
+| `options$`  | `Observable<IVirtualListOptions>` | Options of the virtual list.        |
+| `style`     | `{[key: string]: string|number}`  | Style of VirtualList container.     |
+| `className` | `string`                          | className of VirtualList container. |
+| `keepDom`   | `boolean`                         | Determine whether to reuse the dom. |
+| `uniqKey`   | `string`                          | The key field of list to identify.  |
 
 ### `IVirtualListOptions`
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { BehaviorSubject, combineLatest, of } from 'rxjs';
+import { BehaviorSubject, combineLatest } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { VirtualList } from 'vist';
 
@@ -10,6 +10,7 @@ class App extends Component {
   };
   search$ = new BehaviorSubject(this.state.keyWord);
   data$ = new BehaviorSubject([]);
+  options$ = new BehaviorSubject({ height: 180, startIndex: 3000 });
 
   constructor(props) {
     super(props);
@@ -23,7 +24,7 @@ class App extends Component {
       .then(data => this.data$.next(data))
       .catch(console.error);
 
-    combineLatest(this.data$, this.search$).pipe(
+    combineLatest([this.data$, this.search$]).pipe(
       tap(([data, keyWord]) => this.setState({ keyWord })),
       map(([data, keyWord]) => data.filter(item => {
         if (Number.isNaN(+keyWord)) {
@@ -32,7 +33,10 @@ class App extends Component {
 
         return item.id.toString().includes(keyWord);
       }) || [])
-    ).subscribe(data => this.state.data.next(data));
+    ).subscribe(data => {
+      this.state.data.next(data);
+      this.options$.next({ height: 180, startIndex: 3000 });
+    });
   }
 
   onSearch(e) {
@@ -54,7 +58,7 @@ class App extends Component {
         <div className="virtual-box">
           <VirtualList
             data$={this.state.data}
-            options$={of({ height: 180, startIndex: 3000 })}
+            options$={this.options$}
             style={{ height: '70vh' }}
           >
             {item => (

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -21,7 +21,10 @@ class App extends Component {
   componentDidMount() {
     fetch('https://jsonplaceholder.typicode.com/photos')
       .then(res => res.json())
-      .then(data => this.data$.next(data))
+      .then(data => {
+        this.data$.next(data);
+        this.options$.next({ height: 180, startIndex: 3000 });
+      })
       .catch(console.error);
 
     combineLatest([this.data$, this.search$]).pipe(
@@ -33,10 +36,7 @@ class App extends Component {
 
         return item.id.toString().includes(keyWord);
       }) || [])
-    ).subscribe(data => {
-      this.state.data.next(data);
-      this.options$.next({ height: 180, startIndex: 3000 });
-    });
+    ).subscribe(data => this.state.data.next(data));
   }
 
   onSearch(e) {
@@ -60,6 +60,9 @@ class App extends Component {
             data$={this.state.data}
             options$={this.options$}
             style={{ height: '70vh' }}
+            className="custom-class"
+            keepDom={false}
+            uniqKey="id"
           >
             {item => (
               <div className="card">

--- a/src/VirtualList.service.ts
+++ b/src/VirtualList.service.ts
@@ -1,7 +1,7 @@
 import { RefObject } from 'react';
 import { combineLatest, fromEvent, Observable } from 'rxjs';
 import { debounceTime, filter, map, pairwise, skipWhile, startWith, tap, withLatestFrom } from 'rxjs/operators';
-import { IVirtualListOptions } from './VirtualList';
+import { IDataItem, IVirtualListOptions } from './VirtualList';
 
 function validateOptions(options: IVirtualListOptions): void {
   if (!Reflect.has(options, 'height') || options.height === undefined) {
@@ -89,5 +89,101 @@ export function useIndices(
   return combineLatest([scrollTop$, options$]).pipe(
     // the index of the top elements of the current list
     map(([st, options]) => Math.floor((st as any) / options.height))
+  );
+}
+
+let lastFirstIndex = -1;
+let actualRowsSnapshot = 0;
+
+export function useIndicesInViewport<T>(
+  indices$: Observable<number>,
+  data$: Observable<T[]>,
+  actualRows$: Observable<number>
+): Observable<[number, number]> {
+  return combineLatest([indices$, data$, actualRows$]).pipe(
+    map(([curIndex, data, actualRows]) => {
+      // the first index of the virtualList on the last screen, if < 0, reset to 0
+      const maxIndex = data.length - actualRows < 0 ? 0 : data.length - actualRows;
+      return [Math.min(curIndex, maxIndex), actualRows];
+    }),
+    // if the index or actual rows changed, then update
+    filter(([curIndex, actualRows]) => curIndex !== lastFirstIndex || actualRows !== actualRowsSnapshot),
+    // update the index
+    tap(([curIndex]) => (lastFirstIndex = curIndex)),
+    map(([firstIndex, actualRows]) => {
+      const lastIndex = firstIndex + actualRows - 1;
+      return [firstIndex, lastIndex];
+    })
+  );
+}
+
+let stateDataSnapshot: Array<IDataItem<any>> = [];
+let dataReference: any[] = [];
+
+export function useDataSliceInView<T>(
+  data$: Observable<T[]>,
+  options$: Observable<IVirtualListOptions>,
+  indicesInView$: Observable<[number, number]>,
+  scrollDirection$: Observable<number>,
+  actualRows$: Observable<number>
+): Observable<Array<IDataItem<T>>> {
+  return combineLatest([data$, options$, indicesInView$]).pipe(
+    withLatestFrom(scrollDirection$, actualRows$),
+    map(([[data, options, [firstIndex, lastIndex]], dir, actualRows]) => {
+      const dataSlice = stateDataSnapshot;
+      // compare data reference, if not the same, then update the list
+      const dataReferenceIsSame = data === dataReference;
+
+      // fill the list
+      if (!dataSlice.length || !dataReferenceIsSame || actualRows !== actualRowsSnapshot) {
+        if (!dataReferenceIsSame) {
+          dataReference = data;
+        }
+
+        if (actualRows !== actualRowsSnapshot) {
+          actualRowsSnapshot = actualRows;
+        }
+
+        return (stateDataSnapshot = data.slice(firstIndex, lastIndex + 1).map(item => ({
+          origin: item,
+          $pos: firstIndex * options.height,
+          $index: firstIndex++
+        })));
+      }
+
+      // reuse the existing elements
+      const diffSliceIndexes = getDifferenceIndexes(dataSlice, firstIndex, lastIndex);
+      let newIndex = dir > 0 ? lastIndex - diffSliceIndexes.length + 1 : firstIndex;
+
+      diffSliceIndexes.forEach(index => {
+        const item = dataSlice[index];
+        item.origin = data[newIndex];
+        item.$pos = newIndex * options.height;
+        item.$index = newIndex++;
+      });
+
+      return (stateDataSnapshot = dataSlice);
+    })
+  );
+}
+
+function getDifferenceIndexes<T>(slice: Array<IDataItem<T>>, firstIndex: number, lastIndex: number): number[] {
+  const indexes: number[] = [];
+
+  slice.forEach((item, i) => {
+    if (item.$index < firstIndex || item.$index > lastIndex) {
+      indexes.push(i);
+    }
+  });
+
+  return indexes;
+}
+
+export function useScrollHeight<T>(
+  data$: Observable<T[]>,
+  options$: Observable<IVirtualListOptions>
+): Observable<number> {
+  return combineLatest([data$, options$]).pipe(
+    map(([data, option]) => data.length * option.height)
   );
 }

--- a/src/VirtualList.service.ts
+++ b/src/VirtualList.service.ts
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { fromEvent, Observable } from 'rxjs';
+import { debounceTime, filter, map, skipWhile, startWith, tap, withLatestFrom } from 'rxjs/operators';
+import { IVirtualListOptions } from './VirtualList';
+
+function validateOptions(options: IVirtualListOptions): void {
+  if (!Reflect.has(options, 'height') || options.height === undefined) {
+    throw new Error(`[Vist] You need to pass a valid 'options.height'.`);
+  }
+}
+
+function defaultOptions(options: IVirtualListOptions): IVirtualListOptions {
+  const opt = { ...options };
+
+  opt.sticky = Reflect.has(opt, 'sticky') ? opt.sticky : true;
+  opt.spare = Reflect.has(opt, 'spare') ? opt.spare : 3;
+  opt.startIndex = Reflect.has(opt, 'startIndex') ? opt.startIndex : 0;
+  opt.resize = Reflect.has(opt, 'resize') ? opt.resize : true;
+
+  return opt;
+}
+
+export function useOptions(options$: Observable<IVirtualListOptions>): Observable<IVirtualListOptions> {
+  return options$
+    .pipe(
+      tap(validateOptions),
+      map(defaultOptions)
+    );
+}
+
+export function useContainerHeight(
+  containerRef: React.RefObject<HTMLDivElement>,
+  options$: Observable<IVirtualListOptions>
+): Observable<number> {
+  return fromEvent(window, 'resize')
+    .pipe(
+      filter(() => containerRef.current !== null),
+      withLatestFrom(options$),
+      skipWhile(([_, options]) => !options.resize),
+      startWith(null),
+      debounceTime(200),
+      map(() => containerRef.current!.clientHeight)
+    );
+}

--- a/src/VirtualList.service.ts
+++ b/src/VirtualList.service.ts
@@ -42,3 +42,25 @@ export function useContainerHeight(
       map(() => containerRef.current!.clientHeight)
     );
 }
+
+export function useScrollTop(el: HTMLElement): Observable<number> {
+  const scrollEvent$ = fromEvent(el, 'scroll').pipe(
+    startWith({ target: { scrollTop: 0 } })
+  );
+
+  return scrollEvent$.pipe(map(e => (e.target as HTMLElement).scrollTop));
+}
+
+export function userScrollToPosition(options$: Observable<IVirtualListOptions>): Observable<number> {
+  return options$.pipe(
+    map(option => option.startIndex! * option.height)
+  );
+}
+
+export function useStickyTop<T>(data$: Observable<T[]>, options$: Observable<IVirtualListOptions>) {
+  return data$
+    .pipe(
+      withLatestFrom(options$),
+      filter(([_, options]) => options.sticky!)
+    );
+}

--- a/src/VirtualList.tsx
+++ b/src/VirtualList.tsx
@@ -29,6 +29,8 @@ export interface IVirtualListProps<T> {
   options$: Observable<IVirtualListOptions>;
   style?: { [key: string]: number | string };
   className?: string;
+  keepDom?: boolean;
+  uniqKey?: string;
 }
 
 export interface IDataItem<T> {
@@ -93,7 +95,11 @@ export class VirtualList<T> extends React.Component<Readonly<IVirtualListProps<T
       <div className={cls} ref={this.virtualListRef} style={this.props.style}>
         <div className={style.VirtualListContainer} style={{ height: this.state.scrollHeight }}>
           {this.state.data.map((data, i) => (
-            <div key={i} className={style.VirtualListPlaceholder} style={{ top: data.$pos }}>
+            <div
+              key={this.props.keepDom ? i : (this.props.uniqKey ? data.origin[this.props.uniqKey] : i)}
+              className={style.VirtualListPlaceholder}
+              style={{ top: data.$pos }}
+            >
               {data.origin !== undefined ? (this.props.children as any)(data.origin, data.$index) : null}
             </div>
           ))}

--- a/src/VirtualList.tsx
+++ b/src/VirtualList.tsx
@@ -27,7 +27,8 @@ export interface IVirtualListOptions {
 export interface IVirtualListProps<T> {
   data$: Observable<T[]>;
   options$: Observable<IVirtualListOptions>;
-  style?: any;
+  style?: { [key: string]: number | string };
+  className?: string;
 }
 
 export interface IDataItem<T> {
@@ -86,11 +87,13 @@ export class VirtualList<T> extends React.Component<Readonly<IVirtualListProps<T
   }
 
   render() {
+    const cls = `${style.VirtualList} ${this.props.className || ''}`;
+
     return (
-      <div className={style.VirtualList} ref={this.virtualListRef} style={this.props.style}>
+      <div className={cls} ref={this.virtualListRef} style={this.props.style}>
         <div className={style.VirtualListContainer} style={{ height: this.state.scrollHeight }}>
           {this.state.data.map((data, i) => (
-            <div key={i} className={style.VirtualListPlaceholder} style={{ top: data.$pos + 'px' }}>
+            <div key={i} className={style.VirtualListPlaceholder} style={{ top: data.$pos }}>
               {data.origin !== undefined ? (this.props.children as any)(data.origin, data.$index) : null}
             </div>
           ))}


### PR DESCRIPTION
Refactor VirtualList, extra all the calculation logic into separate service file to make UI component more clean.

Features

* support `className` prop
* won't reuse dom by default. (can switch `keepDom`)

Bugfixes

* fix the conflict of `startIndex` and `sticky` behavior